### PR TITLE
Added checks and error logging to handle migrations that accidentally…

### DIFF
--- a/lib/mongodb-migrations.js
+++ b/lib/mongodb-migrations.js
@@ -134,7 +134,7 @@
       })(this);
       runOne = (function(_this) {
         return function() {
-          var context, donePromise, fn, id, isCallbackCalled, migration, migrationDone, skipCode, skipReason, timeoutId;
+          var context, didExecuteCallback, didReturnPromise, didTimeout, donePromise, fn, id, migration, migrationDone, promiseAndDoneError, skipCode, skipReason, timeoutId;
           if (i >= l) {
             return allDone();
           }
@@ -182,11 +182,22 @@
             });
             return runOne();
           }
-          isCallbackCalled = false;
+          didTimeout = false;
+          didReturnPromise = false;
+          didExecuteCallback = false;
+          promiseAndDoneError = function() {
+            var err;
+            err = new Error("Migration called done() AND returned a promise");
+            migrationDone({
+              status: 'error',
+              error: err
+            });
+            return allDone(err);
+          };
           if (_this._timeout) {
             timeoutId = setTimeout(function() {
               var err;
-              isCallbackCalled = true;
+              didTimeout = true;
               err = new Error("migration timed-out");
               migrationDone({
                 status: 'error',
@@ -200,10 +211,15 @@
             log: userLog
           };
           donePromise = fn.call(context, function(err) {
-            if (isCallbackCalled) {
+            didExecuteCallback = true;
+            if (didTimeout) {
               return;
             }
             clearTimeout(timeoutId);
+            if (didReturnPromise) {
+              promiseAndDoneError();
+              return;
+            }
             if (err) {
               migrationDone({
                 status: 'error',
@@ -218,8 +234,13 @@
             }
           });
           if (donePromise && donePromise.then instanceof Function) {
+            didReturnPromise = true;
+            if (didExecuteCallback) {
+              promiseAndDoneError();
+              return;
+            }
             return donePromise.then(function() {
-              if (isCallbackCalled) {
+              if (didTimeout) {
                 return;
               }
               clearTimeout(timeoutId);
@@ -228,7 +249,7 @@
               });
               return runOne();
             })["catch"](function(err) {
-              if (isCallbackCalled) {
+              if (didTimeout) {
                 return;
               }
               clearTimeout(timeoutId);
@@ -241,7 +262,7 @@
           }
         };
       })(this);
-      runOne();
+      return runOne();
     };
 
     Migrator.prototype.migrate = function(done, progress) {


### PR DESCRIPTION
… return a promise and call the done() callback

## Description
Existing migrations were failing when they accidentally returned a promise and called the done callback. These changes will throw an error explaining the problem along with which migration is at fault.

## Testing
* ran though our migrations and found 8 migrations with these errors
* verified our migrations are running in order with these changes once once I fixed all the errors
* test branch `fix-async-migrations` is available in our migrations repo to test with the fixed migrations. If you do this, you might need to remove `node_modules` and reinstall the packages (npm didn't pick up the changes to package location on my machine)