### PR TITLE
Fixes for mongodb driver 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The configuration object can have the following keys:
 * `ssl` _[optional]_ - boolean, if `true`, `'?ssl=true'` is added to the MongoDB URL,
 * `user` _[optional]_ — MongoDB user name when authentication is required,
 * `password` _[optional]_ — MongoDB password when authentication is required,
-* `authDatabase` _[optional]_ - MongoDB database to authenticate the user against,    
+* `authDatabase` _[optional]_ - MongoDB database to authenticate the user against,
 * `collection` _[optional]_ — The name of the MongoDB collection to track already ran migrations, **defaults to `_migrations`**,
 * `directory` — the directory (path relative to the current folder) to store migration files in and read them from, used when running from the command-line or when using `runFromDir`,
 * `timeout` _[optional]_ — time in milliseconds after which migration should fail if `done()` is not called (use 0 to disable timeout)
@@ -155,12 +155,12 @@ exports.id = 'create-toby';
 
 exports.up = function (done) {
   var coll = this.db.collection('test');
-  coll.insert({ name: 'tobi' }, done);
+  coll.insertOne({ name: 'tobi' }, done);
 };
 
 exports.down = function (done) {
   var coll = this.db.collection('test');
-  coll.remove({}, done);
+  coll.removeMany({}, done);
 };
 ```
 

--- a/bin-src/mm.coffee
+++ b/bin-src/mm.coffee
@@ -70,8 +70,8 @@ dedupe = (opts) ->
   readConfig opts.config
   Promise.fromCallback (cb) ->
     connect config, cb
-  .then (db) ->
-    return db.collection(config.collection)
+  .then (client) ->
+    return client.db().collection(config.collection)
   .then (coll) ->
     console.log('Loading the list of migration records...')
     coll.find({}).toArray()

--- a/bin/mm
+++ b/bin/mm
@@ -99,8 +99,8 @@
     readConfig(opts.config);
     return Promise.fromCallback(function(cb) {
       return connect(config, cb);
-    }).then(function(db) {
-      return db.collection(config.collection);
+    }).then(function(client) {
+      return client.db().collection(config.collection);
     }).then(function(coll) {
       console.log('Loading the list of migration records...');
       return coll.find({}).toArray().then(function(docs) {

--- a/lib/mongodb-migrations.js
+++ b/lib/mongodb-migrations.js
@@ -33,8 +33,9 @@
       this._dbReady = new Promise.fromCallback(function(cb) {
         return mongoConnect(dbConfig, cb);
       }).then((function(_this) {
-        return function(db) {
-          return _this._db = db;
+        return function(client) {
+          _this._client = client;
+          return _this._db = client.db();
         };
       })(this));
       this._collName = dbConfig.collection;
@@ -115,7 +116,7 @@
       handleMigrationDone = function(id) {
         var p;
         p = direction === 'up' ? Promise.fromCallback(function(cb) {
-          return migrationsCollection.insert({
+          return migrationsCollection.insertOne({
             id: id
           }, cb);
         }) : Promise.fromCallback(function(cb) {
@@ -358,7 +359,7 @@
         return function() {
           var e, error;
           try {
-            _this._db.close();
+            _this._client.close();
             return typeof cb === "function" ? cb(null) : void 0;
           } catch (error) {
             e = error;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,14 +17,14 @@
     options = config.options || {};
     poolSize = config.poolSize;
     if (poolSize != null) {
-      console.warn('The `poolSize` config param is deprecated.\nUse `options: { server: { poolSize: poolSize} }` instead.');
-      if (_.get(options, 'server.poolSize')) {
-        console.warn('The `poolSize` is overriding the `options: { server: { poolSize: poolSize} }` value.');
+      console.warn('The `poolSize` config param is deprecated.\nUse `options: { poolSize: poolSize }` instead.');
+      if (_.get(options, 'server.poolSize') || _.get(options, 'poolSize')) {
+        console.warn('The `poolSize` is overriding the `options: { poolSize: poolSize }` value.');
       }
-      _.set(options, 'server.poolSize', poolSize);
+      _.set(options, 'poolSize', poolSize);
     }
-    if (!_.get(options, 'server.poolSize')) {
-      _.set(options, 'server.poolSize', DEFAULT_POOL_SIZE);
+    if (!_.get(options, 'poolSize') && !_.get(options, 'server.poolSize')) {
+      _.set(options, 'poolSize', DEFAULT_POOL_SIZE);
     }
     return options;
   };

--- a/src/mongodb-migrations.coffee
+++ b/src/mongodb-migrations.coffee
@@ -22,8 +22,9 @@ class Migrator
 
     @_dbReady = new Promise.fromCallback (cb) ->
       mongoConnect dbConfig, cb
-    .then (db) =>
-      @_db = db
+    .then (client) =>
+      @_client = client
+      @_db = client.db()
 
     @_collName = dbConfig.collection
     @_timeout = dbConfig.timeout
@@ -255,7 +256,7 @@ class Migrator
     @_isDisposed = true
     onSuccess = =>
       try
-        @_db.close()
+        @_client.close()
         cb?(null)
       catch e
         cb?(e)

--- a/src/mongodb-migrations.coffee
+++ b/src/mongodb-migrations.coffee
@@ -88,7 +88,7 @@ class Migrator
     handleMigrationDone = (id) ->
       p = if direction == 'up'
         Promise.fromCallback (cb) ->
-          migrationsCollection.insert { id }, cb
+          migrationsCollection.insertOne { id }, cb
       else
         Promise.fromCallback (cb) ->
           migrationsCollection.deleteMany { id }, cb

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -14,16 +14,16 @@ exports._buildOptions = _buildOptions = (config) ->
   if poolSize?
     console.warn('''
       The `poolSize` config param is deprecated.
-      Use `options: { server: { poolSize: poolSize} }` instead.
+      Use `options: { poolSize: poolSize }` instead.
     ''')
-    if _.get(options, 'server.poolSize')
+    if _.get(options, 'server.poolSize') || _.get(options, 'poolSize')
       console.warn('''
-        The `poolSize` is overriding the `options: { server: { poolSize: poolSize} }` value.
+        The `poolSize` is overriding the `options: { poolSize: poolSize }` value.
       ''')
-    _.set(options, 'server.poolSize', poolSize)
+    _.set(options, 'poolSize', poolSize)
 
-  if not _.get(options, 'server.poolSize')
-    _.set(options, 'server.poolSize', DEFAULT_POOL_SIZE)
+  if not _.get(options, 'poolSize') && not _.get(options, 'server.poolSize')
+    _.set(options, 'poolSize', DEFAULT_POOL_SIZE)
 
   return options
 

--- a/test/basic.coffee
+++ b/test/basic.coffee
@@ -10,7 +10,7 @@ describe 'Migrator', ->
     testsCommon.beforeEach (res) ->
       {migrator, db} = res
       coll = db.collection 'test'
-      coll.remove {}, ->
+      coll.deleteMany {}, ->
         done()
 
   it 'should exist', (done) ->
@@ -38,7 +38,7 @@ describe 'Migrator', ->
     migrator.add
       id: '1'
       up: (cb) ->
-        coll.insert name: 'tobi', cb
+        coll.insertOne name: 'tobi', cb
     migrator.migrate (err, res) ->
       return done(err) if err
       res.should.be.ok()
@@ -54,7 +54,7 @@ describe 'Migrator', ->
       id: '1'
       up: () ->
         return new Promise((resolve, reject) =>
-          coll.insert name: 'tobi', (err) ->
+          coll.insertOne name: 'tobi', (err) ->
             if err
               reject(err)
             else
@@ -106,10 +106,10 @@ describe 'Migrator', ->
     migrator.add
       id: 1
       up: (cb) ->
-        coll.insert name: 'tobi', cb
+        coll.insertOne name: 'tobi', cb
         return
       down: (cb) ->
-        coll.update { name: 'tobi' }, { name: 'loki' }, cb
+        coll.updateOne { name: 'tobi' }, { $set: { name: 'loki' } }, cb
         return
     migrator.migrate (err, res) ->
       return done(err) if err
@@ -127,9 +127,9 @@ describe 'Migrator', ->
     migrator.add
       id: 1
       up: (cb) ->
-        coll.insert name: 'tobi', cb
+        coll.insertOne name: 'tobi', cb
       down: (cb) ->
-        coll.update { name: 'tobi' }, { name: 'loki' }, cb
+        coll.updateOne { name: 'tobi' }, { $set: { name: 'loki' } }, cb
     migrator.migrate (err, res) ->
       return done(err) if err
       res['1'].should.be.ok()

--- a/test/common.coffee
+++ b/test/common.coffee
@@ -17,6 +17,6 @@ module.exports =
         console.error err
         throw err
       db = client.db()
-      db.collection(config.collection).remove {}, ->
+      db.collection(config.collection).deleteMany {}, ->
         migrator = new mm.Migrator config, null
         done { migrator, db, config }

--- a/test/common.coffee
+++ b/test/common.coffee
@@ -2,7 +2,7 @@ mm = require '../src/mongodb-migrations'
 mongoConnect = require('../src/utils').connect
 
 config =
-  host: 'localhost'
+  host: process.env.DB_HOST || 'localhost'
   port: 27017
   db: '_mm'
   collection: '_migrations'
@@ -12,10 +12,11 @@ module.exports =
   config: config
 
   beforeEach: (done) ->
-    mongoConnect config, (err, db) ->
+    mongoConnect config, (err, client) ->
       if err
         console.error err
         throw err
+      db = client.db()
       db.collection(config.collection).remove {}, ->
         migrator = new mm.Migrator config, null
         done { migrator, db, config }

--- a/test/error.coffee
+++ b/test/error.coffee
@@ -10,7 +10,7 @@ describe 'Migrator Errors Handling', ->
     testsCommon.beforeEach (res) ->
       {migrator, db} = res
       coll = db.collection 'test'
-      coll.remove {}, ->
+      coll.deleteMany {}, ->
         done()
 
   it 'should run migrations and stop on the first error', (done) ->

--- a/test/fromdir.coffee
+++ b/test/fromdir.coffee
@@ -11,7 +11,7 @@ describe 'Migrator from Directory', ->
     testsCommon.beforeEach (res) ->
       {migrator, db} = res
       coll = db.collection 'test'
-      coll.remove {}, ->
+      coll.deleteMany {}, ->
         done()
 
   it 'should run migrations from directory', (done) ->

--- a/test/migrations/1-test1.js
+++ b/test/migrations/1-test1.js
@@ -2,10 +2,10 @@ exports.id = 'test1';
 
 exports.up = function (done) {
   var coll = this.db.collection('test');
-  coll.insert({ name: 'tobi' }, done);
+  coll.insertOne({ name: 'tobi' }, done);
 };
 
 exports.down = function (done) {
   var coll = this.db.collection('test');
-  coll.remove({}, done);
+  coll.deleteMany({}, done);
 };

--- a/test/migrations/2-test2.js
+++ b/test/migrations/2-test2.js
@@ -2,5 +2,5 @@ exports.id = 'test2';
 
 exports.up = function (done) {
   var coll = this.db.collection('test');
-  coll.insert({ name: 'loki' }, done);
+  coll.insertOne({ name: 'loki' }, done);
 };

--- a/test/migrations/3-test3.js
+++ b/test/migrations/3-test3.js
@@ -2,5 +2,5 @@ exports.id = 'test3';
 
 exports.up = function (done) {
   var coll = this.db.collection('test');
-  coll.update({ name: { $in: ['loki', 'tobi'] } }, { $set: { ok: 1 } }, { multi: true }, done);
+  coll.updateMany({ name: { $in: ['loki', 'tobi'] } }, { $set: { ok: 1 } }, done);
 };

--- a/test/migrations/4-runFromDir-should-find-coffee.coffee
+++ b/test/migrations/4-runFromDir-should-find-coffee.coffee
@@ -1,4 +1,4 @@
 module.exports.id = "runFromDir-should-find-coffee"
 
 module.exports.up = (done) ->
-  @db.collection('test').insert({ name: '123', ok: 1 }, done);
+  @db.collection('test').insertOne({ name: '123', ok: 1 }, done);

--- a/test/no-duplicate-records.coffee
+++ b/test/no-duplicate-records.coffee
@@ -12,14 +12,14 @@ describe 'Migrations Collection', ->
       {migrator, db, config} = res
       migrationColl = db.collection(config.collection)
       coll = db.collection 'test'
-      coll.remove {}, ->
+      coll.deleteMany {}, ->
         done()
 
   it 'should run migrations and only record them once', (done) ->
     migrator.add
       id: 'm1'
       up: (cb) ->
-        coll.insert name: 'tobi', cb
+        coll.insertOne name: 'tobi', cb
     migrator.migrate (err, res) ->
       return done(err) if err
       coll.find({name: 'tobi'}).count (err, count) ->

--- a/test/rollback.coffee
+++ b/test/rollback.coffee
@@ -11,7 +11,7 @@ describe 'Migrator Rollback', ->
     testsCommon.beforeEach (res) ->
       {migrator, db} = res
       coll = db.collection 'test'
-      coll.remove {}, ->
+      coll.deleteMany {}, ->
         done()
 
   it 'should cleanup the migrations collection properly', (done) ->

--- a/test/util.coffee
+++ b/test/util.coffee
@@ -10,7 +10,7 @@ describe 'Utils', ->
                     a: 1
             _buildOptions(config).should.be.deepEqual({
                 a: 1
-                server: poolSize: 5
+                poolSize: 5
             })
             done()
 
@@ -20,22 +20,23 @@ describe 'Utils', ->
                     a: b: 'c'
             _buildOptions(config).should.be.deepEqual({
                 a: b: 'c'
-                server: poolSize: 5
+                poolSize: 5
             })
             done()
 
         it 'should normalize null options and set the default `poolSize` of 5', (done) ->
             config = { otherKey: 'x' }
-            _buildOptions(config).should.be.deepEqual({ server: poolSize: 5 })
+            _buildOptions(config).should.be.deepEqual({ poolSize: 5 })
             done()
 
+        # xxx remove
         it 'should properly merge the `server` key and set the default `poolSize` of 5', (done) ->
             config =
                 options:
                     server: x: 1
             _buildOptions(config).should.be.deepEqual({
+                poolSize: 5
                 server:
-                    poolSize: 5
                     x: 1
             })
             done()
@@ -55,26 +56,26 @@ describe 'Utils', ->
 
         it '[compat] should normalize null options and set the custom `poolSize`', (done) ->
             config = { otherKey: 'x', poolSize: 7 }
-            _buildOptions(config).should.be.deepEqual({ server: poolSize: 7 })
+            _buildOptions(config).should.be.deepEqual({ poolSize: 7 })
             done()
 
         it '[compat] should support `poolSize` with null options', (done) ->
             config = { otherKey: 'x', poolSize: 2 }
-            _buildOptions(config).should.be.deepEqual({ server: poolSize: 2 })
+            _buildOptions(config).should.be.deepEqual({ poolSize: 2 })
             done()
 
         it '[compat] should override the `poolSize` if provided as a separate option', (done) ->
             config = {
                 options:
+                    poolSize: 2
                     server:
                         x: 1
-                        poolSize: 2
                 poolSize: 4
             }
             _buildOptions(config).should.be.deepEqual({
+                poolSize: 4
                 server:
                     x: 1
-                    poolSize: 4
             })
             done()
 


### PR DESCRIPTION
Updated for MongoClient changes from https://github.com/mongodb/node-mongodb-native/blob/3.6/CHANGES_3.0.0.md. The connect call no longer returns a `Db`, it returns a `MongoClient`.

Also fixed deprecation warnings.

With these changes, the unit tests pass.