### PR TITLE
Adding a client variable for context

### DIFF
--- a/lib/mongodb-migrations.js
+++ b/lib/mongodb-migrations.js
@@ -209,7 +209,8 @@
           }
           context = {
             db: _this._db,
-            log: userLog
+            log: userLog,
+            client: _this._client
           };
           donePromise = fn.call(context, function(err) {
             didExecuteCallback = true;

--- a/src/mongodb-migrations.coffee
+++ b/src/mongodb-migrations.coffee
@@ -157,7 +157,7 @@ class Migrator
           allDone(err)
         , @_timeout
 
-      context = { db: @_db, log: userLog }
+      context = { db: @_db, log: userLog, client: @_client }
 
       donePromise = fn.call context, (err) ->
         didExecuteCallback = true;


### PR DESCRIPTION
This will allow the client to be directly accessible in our migration scripts, allowing tenant level migrations to be possible