### PR TITLE
AIA-32657: Add type exports to get autocomplete working

### DIFF
--- a/lib/mongodb-migrations.d.ts
+++ b/lib/mongodb-migrations.d.ts
@@ -2,23 +2,23 @@ import { Db, MongoClient } from "mongodb";
 import { MongoConfig } from "./types";
 export type LogLevel = "system" | "user";
 type LogFunction = ((level: LogLevel, message: string) => void) | null;
-type MigrationFunction = (this: MigrationContext) => Promise<void>;
-interface Migration {
+export type MigrationFunction = (this: MigrationContext) => Promise<void>;
+export interface Migration {
     id: string;
     up?: MigrationFunction;
     down?: MigrationFunction;
 }
-type MigrationStatus = "ok" | "skip" | "error";
-interface MigrationResult {
+export type MigrationStatus = "ok" | "skip" | "error";
+export interface MigrationResult {
     status: MigrationStatus;
     error?: Error;
     reason?: string;
     code?: "no_up" | "no_down" | "already_ran" | "not_in_recent_migrate";
 }
-interface MigrationResults {
+export interface MigrationResults {
     [key: string]: MigrationResult;
 }
-interface MigrationContext {
+export interface MigrationContext {
     db: Db;
     log: (message: string) => void;
     client: MongoClient;

--- a/src/mongodb-migrations.ts
+++ b/src/mongodb-migrations.ts
@@ -16,28 +16,28 @@ const defaultLog = (src: LogLevel, ...args: any[]): void => {
     console.log(pad, ...args);
 };
 
-type MigrationFunction = (this: MigrationContext) => Promise<void>;
+export type MigrationFunction = (this: MigrationContext) => Promise<void>;
 
-interface Migration {
+export interface Migration {
     id: string;
     up?: MigrationFunction;
     down?: MigrationFunction;
 }
 
-type MigrationStatus = "ok" | "skip" | "error";
+export type MigrationStatus = "ok" | "skip" | "error";
 
-interface MigrationResult {
+export interface MigrationResult {
     status: MigrationStatus;
     error?: Error;
     reason?: string;
     code?: "no_up" | "no_down" | "already_ran" | "not_in_recent_migrate";
 }
 
-interface MigrationResults {
+export interface MigrationResults {
     [key: string]: MigrationResult;
 }
 
-interface MigrationContext {
+export interface MigrationContext {
     db: Db;
     log: (message: string) => void;
     client: MongoClient;


### PR DESCRIPTION
Usage:
```
import type { MigrationContext } from "mongodb-migrations";

export async function up(this: MigrationContext) {
    const db = this.db;
}
```
Not super familiar with mongo so I found it annoying that autocomplete wasnt working.